### PR TITLE
Update panic.rs, fix "cargo test --lib" not working

### DIFF
--- a/src/panic.rs
+++ b/src/panic.rs
@@ -24,7 +24,7 @@ fn panic(panic_info: &PanicInfo) -> ! {
 			#[cfg(config_debug_qemu)]
 			selftest::qemu::exit(selftest::qemu::FAILURE);
 			#[cfg(not(config_debug_qemu))]
-			halt();
+			power::halt();
 		}
 	}
 


### PR DESCRIPTION
Gives this without this fix:

error[E0425]: cannot find function `halt` in this scope
  --> src/panic.rs:27:4
   |
27 |             halt();
   |             ^^^^ not found in this scope
   |
help: consider importing this function
   |
7  + use crate::power::halt;
   |

For more information about this error, try `rustc --explain E0425`.
error: could not compile `maestro` (lib test) due to previous error

with this fix compiles succesfully